### PR TITLE
Keep use ssl, compression, max_latency_ms settings

### DIFF
--- a/galera_check.pl
+++ b/galera_check.pl
@@ -1196,7 +1196,7 @@ sub get_proxy($$$$){
       #}
       #(9000 + $proxynode->{_hg_writer_id})
       
-      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections});";
+      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,use_ssl) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections},$self->{_use_ssl});";
       if($Galera_cluster->{_singlewriter} > 0){
          my $delete = "DELETE from mysql_servers where hostgroup_id in ($proxynode->{_hg_writer_id},".(9000 + $proxynode->{_hg_writer_id}).") AND STATUS = 'ONLINE'".$exclude_delete;
         print Utils->print_log(2," DELETE from writer group as: " 

--- a/galera_check.pl
+++ b/galera_check.pl
@@ -1196,7 +1196,7 @@ sub get_proxy($$$$){
       #}
       #(9000 + $proxynode->{_hg_writer_id})
       
-      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,use_ssl) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections},$self->{_use_ssl});";
+      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,use_ssl,compression,max_latency_ms) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections},$self->{_use_ssl},$self->{_compression},$self->{_max_latency_ms});";
       if($Galera_cluster->{_singlewriter} > 0){
          my $delete = "DELETE from mysql_servers where hostgroup_id in ($proxynode->{_hg_writer_id},".(9000 + $proxynode->{_hg_writer_id}).") AND STATUS = 'ONLINE'".$exclude_delete;
         print Utils->print_log(2," DELETE from writer group as: " 


### PR DESCRIPTION
New writer resets to default values of use_ssl, compression and max_latency_ms on failover. This change makes the values stay as configured instead.