### PR TITLE
fix max_latency variable name

### DIFF
--- a/galera_check.pl
+++ b/galera_check.pl
@@ -1196,7 +1196,7 @@ sub get_proxy($$$$){
       #}
       #(9000 + $proxynode->{_hg_writer_id})
       
-      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,use_ssl,compression,max_latency_ms) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections},$self->{_use_ssl},$self->{_compression},$self->{_max_latency_ms});";
+      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,use_ssl,compression,max_latency_ms) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections},$self->{_use_ssl},$self->{_compression},$self->{_max_latency});";
       if($Galera_cluster->{_singlewriter} > 0){
          my $delete = "DELETE from mysql_servers where hostgroup_id in ($proxynode->{_hg_writer_id},".(9000 + $proxynode->{_hg_writer_id}).") AND STATUS = 'ONLINE'".$exclude_delete;
         print Utils->print_log(2," DELETE from writer group as: " 


### PR DESCRIPTION
My mistake: the field in mysql_servers is max_latency_ms, but in the script it is called _max_latency, without _ms. My previous change regarding this actually breaks failover since inserting to mysql_servers fails. That leads to the error mentioned in https://github.com/Tusamarco/proxy_sql_tools/issues/19#issuecomment-751544967.

