### PR TITLE
Ssl implementation

### DIFF
--- a/galera_check.pl
+++ b/galera_check.pl
@@ -1251,7 +1251,7 @@ sub get_proxy($$$$){
       #}
       #(9000 + $proxynode->{_hg_writer_id})
       
-      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,use_ssl,compression,max_latency_ms) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections},$self->{_use_ssl},$self->{_compression},$self->{_max_latency_ms});";
+      my $proxy_sql_command= "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,max_connections,use_ssl,compression,max_latency_ms) VALUES ('$self->{_ip}',$proxynode->{_hg_writer_id},$self->{_port},$self->{_weight},$self->{_connections},$self->{_use_ssl},$self->{_compression},$self->{_max_latency});";
       if($Galera_cluster->{_singlewriter} > 0){
          my $delete = "DELETE from mysql_servers where hostgroup_id in ($proxynode->{_hg_writer_id},".(9000 + $proxynode->{_hg_writer_id}).") AND STATUS = 'ONLINE'".$exclude_delete;
         print Utils->print_log(2," DELETE from writer group as: " 

--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,20 @@ sample [options] [file ...]
    --development      When set to 1 you can run the script in a loop from bash directly and test what is going to happen
    --development_time Time in seconds that the loop wait to execute when in development mode (default 2 seconds)
 
+   SSL support
+   Now the script identify if the node in the ProxySQL table mysql_servers has use_ssl = 1 and will set SSL to be used for that specific entry.
+   This means that SSL connection is by ProxySQL mysql_server entry NOT by IP:port combination.
+   
+   --ssl_cert_paths This parameter allow you to specify a DIRECTORY to use to assign specific certificates.
+                    At the moment is NOT possible to change the files names and ALL these 3 files must be there and named as follow:
+                     -  client-key.pem
+                     -  client-cert.pem
+                     -  ca.pem
+                     Script will exit with an error if ssl_cert_pathsis declared but not filled properly
+                     OR if the user running the script doesn't have acces.
+   !!NOTE!! SSL connection requires more time to be established. This script is a check that needs to run very fast and constantly.
+            force it to use ssl WILL impact in the performance of the check. Tune properly the check_timeout parameter.
+
 ```   
 
 Note that galera_check is also Segment aware, as such the checks on the presence of Writer /reader is done by segment, respecting the MainSegment as primary.


### PR DESCRIPTION
SSL support implementation.
# SSL support
   Now the script identify if the node in the ProxySQL table mysql_servers has use_ssl = 1 and will set SSL to be used for that specific entry.
   This means that SSL connection is by ProxySQL mysql_server entry NOT by IP:port combination.
   
   --ssl_certs_path This parameter allow you to specify a DIRECTORY to use to assign specific certificates.
                    At the moment is NOT possible to change the files names and ALL these 3 files must be there and named as follow:
-  client-key.pem
-  client-cert.pem
-  ca.pem
Script will exit with an error if ssl_certs_pathis declared but not filled properly OR if the user running the script doesn't have access.

 __!!NOTE!!__  SSL connection requires more time to be established. This script is a check that needs to run very fast and constantly.
            force it to use ssl WILL impact in the performance of the check. Tune properly the check_timeout parameter.